### PR TITLE
Made Pranajaya Dibyacita | Register for OpenGuild FRAME Challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Go to **Participant Registration** section and register to be the workshop parti
 
 ```
 | 🦄 | Name | Github username | Your current occupation |
-| 1 | Made Pranajaya Dibyacita | mdprana | Computer Science |
+| 1 | Made Pranajaya Dibyacita | mdprana | Computer Science Student |
 ```
 
 - Step 5: `Commit` your code and push to the forked Github repository
@@ -95,3 +95,8 @@ OpenGuild is a builder-driven community centered around Polkadot. OpenGuild is b
 - **Website:** [OpenGuild Website](https://openguild.wtf/)
 - **Github:** [OpenGuild Labs](https://github.com/openguild-labs)
 - **Discord**: [Openguild Discord Channel](https://discord.gg/bcjMzxqtD7)
+
+## Participant Registration
+
+| 🦄 | Name | Github username | Your current occupation |
+| 1 | Made Pranajaya Dibyacita | [mdprana](https://github.com/mdprana) | Computer Science Student |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Go to **Participant Registration** section and register to be the workshop parti
 
 ```
 | 🦄 | Name | Github username | Your current occupation |
+| 1 | Made Pranajaya Dibyacita | mdprana | Computer Science |
 ```
 
 - Step 5: `Commit` your code and push to the forked Github repository

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -16,32 +16,65 @@ pub struct StakingPallet<T: StakingConfig> {
 
 impl<T: StakingConfig> StakingPallet<T> {
     pub fn new() -> Self {
-        todo!()
+        Self {
+            free_balances: HashMap::new(),
+            staked_balances: HashMap::new(),
+        }
     }
 
     // Set free balance for an account
     pub fn set_balance(&mut self, who: T::AccountId, amount: T::Balance) {
-        todo!()
+        self.free_balances.insert(who, amount);
     }
 
     // Stake tokens (move from free to staked)
     pub fn stake(&mut self, who: T::AccountId, amount: T::Balance) -> Result<(), &'static str> {
-        todo!()
+        let free_balance = self.get_free_balance(who.clone());
+        
+        if let Some(new_free_balance) = free_balance.checked_sub(&amount) {
+            self.free_balances.insert(who.clone(), new_free_balance);
+            
+            let staked_balance = self.get_staked_balance(who.clone());
+            if let Some(new_staked_balance) = staked_balance.checked_add(&amount) {
+                self.staked_balances.insert(who, new_staked_balance);
+                Ok(())
+            } else {
+                self.free_balances.insert(who, free_balance);
+                Err("Staked balance would overflow")
+            }
+        } else {
+            Err("Not enough free balance to stake")
+        }
     }
 
     // Unstake tokens (move from staked to free)
     pub fn unstake(&mut self, who: T::AccountId, amount: T::Balance) -> Result<(), &'static str> {
-        todo!()
+        let staked_balance = self.get_staked_balance(who.clone());
+        
+        if let Some(new_staked_balance) = staked_balance.checked_sub(&amount) {
+            self.staked_balances.insert(who.clone(), new_staked_balance);
+            
+            let free_balance = self.get_free_balance(who.clone());
+            if let Some(new_free_balance) = free_balance.checked_add(&amount) {
+                self.free_balances.insert(who, new_free_balance);
+                Ok(())
+            } else {
+                self.staked_balances.insert(who, staked_balance);
+                Err("Free balance would overflow")
+            }
+        } else {
+            Err("Not enough staked balance to unstake")
+        }
     }
 
     // Get free balance for an account
     pub fn get_free_balance(&self, who: T::AccountId) -> T::Balance {
-        todo!()
+        *self.free_balances.get(&who).unwrap_or(&T::Balance::zero())
     }
 
     // Get staked balance for an account
     pub fn get_staked_balance(&self, who: T::AccountId) -> T::Balance {
-        todo!()
+        *self.staked_balances.get(&who).unwrap_or(&T::Balance::zero())
     }
 }
 


### PR DESCRIPTION
In this FRAME Pallet Challenge, I implemented two core components of a Substrate blockchain. All tests passed successfully and showing that my code works correctly in different situations. It properly handles error cases like when someone tries to stake more tokens than they have or when they try to vote on a proposal that's already been finalized.

[**For the Governance Pallet:**](https://github.com/openguild-labs/mandala-bootcamp-challenge/commit/ae8500eb59d7c0ca4f97e1935318aa7c5f8406e3#diff-0686b3a718ba3b31101a5933dafbef35cdaf11f749c2706afc228e99800bcb52)
- Built an on-chain proposal and voting system
- Made the `Proposal<T>` struct generic to properly store creator information
- Added `#[derive(Clone, PartialEq)]` to the `ProposalStatus` enum for comparison operations
- Implemented voting functionality with protection against double voting
- Created methods to retrieve proposal details including descriptions and creators

[**For the Staking Pallet:** ](https://github.com/openguild-labs/mandala-bootcamp-challenge/commit/ae8500eb59d7c0ca4f97e1935318aa7c5f8406e3#diff-0ac81041c49f75357b1f4e786bf5d4c2aba5f79ac75d9ac87732d35d8f4fd714)
- Created functionality to track both free and staked token 
- Implemented robust error handling using checked arithmetic operations
- Added protection against overflows and underflows with `checked_add` and `checked_sub`
- Wrote the code to properly handle insufficient balances during staking/unstaking

**Implementation Details:**
- Used Rust's `Result `type for proper error handling across all operations
- Employed pattern matching with `if let` and `match` for cleaner code
- Implemented helper methods like `get_proposal_details` for easier data access
- Made both pallets compatible with the same runtime configuration

![image](https://github.com/user-attachments/assets/48eb5f6b-daef-4a87-8647-7cff9675aab1)
